### PR TITLE
Added backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To download to a different directory:
 download-model https://civitai.com/api/download/models/46846 /workspace/stable-diffusion-webui/models/Stable-diffusion
 ```
 
+The environment variable `CIVITAI_TOKEN` used to retrieve the token from the env is configurable via the env variable `CIVITAI_TOKEN_NAME`. Is also possible to configure the CivitAI download url using the env variable `CIVITAI_BASE_URL`
+
 ## Community and Contributing
 
 Pull requests and issues on [GitHub](https://github.com/ashleykleynhans/civitai-downloader)

--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ chmod +x /usr/local/bin/download-model
 ## Usage
 
 ```bash
+export CIVITAI_TOKEN=<your_token>
 download-model [MODEL_ID_OR_URL] [DESTINATION]
 ```
 
 To download to the current directory:
 
 ```bash
+export CIVITAI_TOKEN=<your_token>
+
 # Example download with model_id:
 download-model 46846 .
 

--- a/README.md
+++ b/README.md
@@ -24,27 +24,29 @@ chmod +x /usr/local/bin/download-model
 > user.  If not, the installation commands should be prefixed
 > with `sudo`.
 
-> [!IMPORTANT]
-> It is important to ensure that you use the **DOWNLOAD** link
-> and not the link to the model page in CivitAI.
-> You can get the model id even from CivitAI main url. Eg. `https://civitai.com/models/1234567?modelVersionId=46846` the model_id will be `46846`
-
 ## Usage
 
 ```bash
-download-model [MODEL_ID] [DESTINATION]
+download-model [MODEL_ID_OR_URL] [DESTINATION]
 ```
 
 To download to the current directory:
 
 ```bash
+# Example download with model_id:
 download-model 46846 .
+
+# Example download with model dowload url:
+download-model https://civitai.com/api/download/models/46846 .
+
+# Example download with model url:
+download-model "https://civitai.com/models/12345678?modelVersionId=46846" .
 ```
 
 To download to a different directory:
 
 ```bash
-download-model 46846 /workspace/stable-diffusion-webui/models/Stable-diffusion
+download-model https://civitai.com/api/download/models/46846 /workspace/stable-diffusion-webui/models/Stable-diffusion
 ```
 
 ## Community and Contributing

--- a/download.py
+++ b/download.py
@@ -141,7 +141,10 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
         total_size = int(total_size)
 
     output_file = os.path.join(output_path, filename)
-
+    if os.path.isfile(output_file) and os.path.getsize(output_file) > 0:
+        print(f'File {output_file} already present on filesystem')
+        return 
+    
     with open(output_file, 'wb') as f:
         downloaded = 0
         start_time = time.time()

--- a/download.py
+++ b/download.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
-import os
-import re
-import sys
+import os, re, sys, time
 import argparse
-import time
 import urllib.request
 import zipfile
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs, unquote
+from typing import Optional
 
 
 CHUNK_SIZE = 1638400
@@ -37,7 +35,7 @@ def get_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def get_token() -> str | None:
+def get_token() -> Optional[str]:
     token = os.getenv(DEFAULT_ENV_NAME, None)
     if token:
         return token
@@ -62,7 +60,7 @@ def prompt_for_civitai_token() -> str:
     return token
 
 
-def extract_id(url: str) -> str | None:
+def extract_id(url: str) -> Optional[str]:
     """
     Extracts the model version ID from a CivitAI URL.
     

--- a/download.py
+++ b/download.py
@@ -17,7 +17,7 @@ DEFAULT_ENV_NAME = os.getenv('CIVITAI_TOKEN_NAME', 'CIVITAI_TOKEN')
 CIVITAI_BASE_URL = os.getenv('CIVITAI_BASE_URL', 'https://civitai.com/api/download/models')
 
 
-def get_args():
+def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description='CivitAI Downloader',
     )

--- a/download.py
+++ b/download.py
@@ -130,8 +130,12 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
                 raise Exception('Unable to determine filename')
 
         # Add headers to the second call
-        redirect_request = urllib.request.Request(redirect_url, headers=headers)
-        response = opener.open(redirect_request)
+        try:
+            redirect_request = urllib.request.Request(redirect_url)
+            response = opener.open(redirect_request)
+        except Exception as e:
+            redirect_request = urllib.request.Request(redirect_url, headers=headers)
+            response = opener.open(redirect_request)
     elif response.status == 404:
         raise Exception('File not found')
     else:

--- a/download.py
+++ b/download.py
@@ -74,6 +74,7 @@ def extract_id(url: str) -> Optional[str]:
 
 
 def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
+
     headers = {
         'Authorization': f'Bearer {token}',
         'User-Agent': USER_AGENT,
@@ -85,6 +86,7 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
             return response
         https_response = http_response
 
+    url = None
     if model_url_or_id.isdigit():
         url = f'{CIVITAI_BASE_URL}/{model_url_or_id}'
     elif CIVITAI_BASE_URL in model_url_or_id:
@@ -93,10 +95,10 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
         model_id = extract_id(model_url_or_id)
         if model_id:
             url = f'{CIVITAI_BASE_URL}/{model_id}'
-    
+
     if not url:
         raise Exception('Invalid model URL or ID')
-        
+
     request = urllib.request.Request(url, headers=headers)
     opener = urllib.request.build_opener(NoRedirection)
     response = opener.open(request)
@@ -127,22 +129,23 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
             if not filename:
                 raise Exception('Unable to determine filename')
 
-        response = urllib.request.urlopen(redirect_url)
+        # Add headers to the second call
+        redirect_request = urllib.request.Request(redirect_url, headers=headers)
+        response = opener.open(redirect_request)
     elif response.status == 404:
         raise Exception('File not found')
     else:
         raise Exception('No redirect found, something went wrong')
 
     total_size = response.getheader('Content-Length')
-
     if total_size is not None:
         total_size = int(total_size)
 
     output_file = os.path.join(output_path, filename)
     if os.path.isfile(output_file) and os.path.getsize(output_file) > 0:
         print(f'File {output_file} already present on filesystem')
-        return 
-    
+        return
+
     with open(output_file, 'wb') as f:
         downloaded = 0
         start_time = time.time()
@@ -160,7 +163,7 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
             chunk_time = chunk_end_time - chunk_start_time
 
             if chunk_time > 0:
-                speed = len(buffer) / chunk_time / (1024 ** 2)  # Speed in MB/s
+                speed = len(buffer) / chunk_time / (1024 ** 2) # Speed in MB/s
 
             if total_size is not None:
                 progress = downloaded / total_size

--- a/download.py
+++ b/download.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import os, re, sys, time
+import os, re, sys, time, json
 import argparse
 import urllib.request
 import zipfile
@@ -7,12 +7,11 @@ from pathlib import Path
 from urllib.parse import urlparse, parse_qs, unquote
 from typing import Optional
 
-
 CHUNK_SIZE = 1638400
 TOKEN_FILE = Path.home() / '.civitai' / 'config'
 USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
 DEFAULT_ENV_NAME = os.getenv('CIVITAI_TOKEN_NAME', 'CIVITAI_TOKEN')
-CIVITAI_BASE_URL = os.getenv('CIVITAI_BASE_URL', 'https://civitai.com/api/download/models')
+CIVITAI_BASE_URL = os.getenv('CIVITAI_BASE_URL', 'https://civitai.com/api')
 
 
 def get_args() -> argparse.Namespace:
@@ -23,7 +22,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument(
         'model_url_or_id',
         type=str,
-        help='CivitAI Download Model ID, eg: 46846'
+        help='Model Version Id or full URL, eg: 46846 or https://civitai.com/models/1234567?modelVersionId=46846'
     )
 
     parser.add_argument(
@@ -73,6 +72,36 @@ def extract_id(url: str) -> Optional[str]:
     return None
 
 
+def get_model_name(model_id: str, headers: dict, url: str) -> str:
+    filename = None
+    if model_id:
+        model_details_req = urllib.request.Request(f'{CIVITAI_BASE_URL}/v1/model-versions/{model_id}', headers=headers)
+        model_details_resp = urllib.request.urlopen(model_details_req)
+        try:
+            json_resp = json.loads(model_details_resp.read().decode('utf-8'))
+            model_files = json_resp['files']
+            primary_file = next((f for f in model_files if f.get('primary')), None)
+            if primary_file:
+                filename = primary_file['name']
+        except Exception as e:
+            print('Cannot retreive model version details from CivitAI API, falling back to filename extraction from URL')
+    
+    if not filename:
+        # Extract filename from the redirect URL
+        parsed_url = urlparse(url)
+        query_params = parse_qs(parsed_url.query)
+        content_disposition = query_params.get('response-content-disposition', [None])[0]
+
+        if content_disposition and 'filename=' in content_disposition:
+            filename = unquote(content_disposition.split('filename=')[1].strip('"'))
+        else:
+            # Fallback: extract filename from URL path
+            path = parsed_url.path
+            if path and '/' in path:
+                filename = path.split('/')[-1]
+    return filename
+
+
 def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
 
     headers = {
@@ -89,14 +118,17 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
     url = None
     initial_response = None
     final_response = None
+    model_id = None
     if model_url_or_id.isdigit():
-        url = f'{CIVITAI_BASE_URL}/{model_url_or_id}'
-    elif CIVITAI_BASE_URL in model_url_or_id:
+        model_id = model_url_or_id
+        url = f'{CIVITAI_BASE_URL}/download/models/{model_id}'
+    elif f'{CIVITAI_BASE_URL}/download/models/' in model_url_or_id:
+        model_id = model_url_or_id.split('/')[-1]
         url = model_url_or_id
     elif 'modelVersionId' in model_url_or_id:
         model_id = extract_id(model_url_or_id)
         if model_id:
-            url = f'{CIVITAI_BASE_URL}/{model_id}'
+            url = f'{CIVITAI_BASE_URL}/download/models/{model_id}'
 
     if not url:
         raise Exception('Invalid model URL or ID')
@@ -112,24 +144,6 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
         if redirect_url.startswith('/'):
             base_url = urlparse(url)
             redirect_url = f"{base_url.scheme}://{base_url.netloc}{redirect_url}"
-
-        # Extract filename from the redirect URL
-        parsed_url = urlparse(redirect_url)
-        query_params = parse_qs(parsed_url.query)
-        content_disposition = query_params.get('response-content-disposition', [None])[0]
-
-        if content_disposition and 'filename=' in content_disposition:
-            filename = unquote(content_disposition.split('filename=')[1].strip('"'))
-        else:
-            # Fallback: extract filename from URL path
-            path = parsed_url.path
-            if path and '/' in path:
-                filename = path.split('/')[-1]
-            else:
-                filename = 'downloaded_file'
-
-            if not filename:
-                raise Exception('Unable to determine filename')
 
         # Add headers to the second call
         redirect_request = urllib.request.Request(redirect_url, headers=headers)
@@ -149,6 +163,11 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
     if total_size is not None:
         total_size = int(total_size)
 
+    filename = get_model_name(model_id, headers, redirect_url if final_response else url)
+    if not filename:
+        raise Exception('Unable to determine filename from CivitAI API or URL')
+
+    print(f'Starting download: {filename}')
     output_file = os.path.join(output_path, filename)
     if os.path.isfile(output_file) and os.path.getsize(output_file) > 0:
         print(f'File {output_file} already present on filesystem')

--- a/download.py
+++ b/download.py
@@ -87,6 +87,8 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
         https_response = http_response
 
     url = None
+    initial_response = None
+    final_response = None
     if model_url_or_id.isdigit():
         url = f'{CIVITAI_BASE_URL}/{model_url_or_id}'
     elif CIVITAI_BASE_URL in model_url_or_id:
@@ -101,10 +103,10 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
 
     request = urllib.request.Request(url, headers=headers)
     opener = urllib.request.build_opener(NoRedirection)
-    response = opener.open(request)
+    initial_response = opener.open(request)
 
-    if response.status in [301, 302, 303, 307, 308]:
-        redirect_url = response.getheader('Location')
+    if initial_response.status in [301, 302, 303, 307, 308]:
+        redirect_url = initial_response.getheader('Location')
 
         # Handle relative redirects
         if redirect_url.startswith('/'):
@@ -130,18 +132,20 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
                 raise Exception('Unable to determine filename')
 
         # Add headers to the second call
-        try:
+        redirect_request = urllib.request.Request(redirect_url, headers=headers)
+        final_response = opener.open(redirect_request)
+        if final_response.status == 400:
             redirect_request = urllib.request.Request(redirect_url)
-            response = opener.open(redirect_request)
-        except Exception as e:
-            redirect_request = urllib.request.Request(redirect_url, headers=headers)
-            response = opener.open(redirect_request)
-    elif response.status == 404:
+            final_response = opener.open(redirect_request)
+    elif initial_response.status == 404:
         raise Exception('File not found')
     else:
         raise Exception('No redirect found, something went wrong')
 
-    total_size = response.getheader('Content-Length')
+    # Use final_response if redirect occurred, otherwise use initial_response
+    download_response = final_response if final_response else initial_response
+
+    total_size = download_response.getheader('Content-Length')
     if total_size is not None:
         total_size = int(total_size)
 
@@ -156,7 +160,7 @@ def download_file(model_url_or_id: str, output_path: str, token: str) -> None:
 
         while True:
             chunk_start_time = time.time()
-            buffer = response.read(CHUNK_SIZE)
+            buffer = download_response.read(CHUNK_SIZE)
             chunk_end_time = time.time()
 
             if not buffer:


### PR DESCRIPTION
Added backwards compatibility to PR #7

Is now possible to use as download parameter one of:

- model id (46846)
- model download url (https://civitai.com/api/download/models/46846)
- model url (https://civitai.com/models/12345678?modelVersionId=46846)

If the model is already present on the fs, and if the file is not empty the script does not override the file.

Fixed code annotation

Updated README